### PR TITLE
Hinzufügen des on_game_launched-Events

### DIFF
--- a/ProjectL.pyw
+++ b/ProjectL.pyw
@@ -33,6 +33,10 @@ class Game(Source.EngineL.Core.SinglePlayerApp):
         except Exception as err:
             self.crash(str(err))
 
+        for child in self.children():
+            if issubclass(child.__class__, Source.EngineL.Core.Entity):
+                child.on_game_launched()
+
 if __name__ == "__main__":
     import sys
     GAME_INSTANCE = Game(sys.argv)

--- a/Source/EngineL/Core.py
+++ b/Source/EngineL/Core.py
@@ -184,6 +184,16 @@ class Entity(QObject):
             if issubclass(child.__class__, Entity):
                 child.on_transfer(subject, parent, target)
 
+    def on_game_launched(self):
+        """
+        This semi-abstract method gets only called when the game has started. At default, it only
+        passes the event to our children, but I can override it in any other way.
+        """
+        for child in self.children():
+            if issubclass(child.__class__, Entity):
+                child.on_game_launched()
+
+
     def talk_to(self, target_name):
         """
         This non-constant method starts a conversation with another entity by calling it's


### PR DESCRIPTION
Der PR enthält eine neue Methode für die Entity-Klasse, die aufgerufen wird, wenn das Spiel startet: `on_game_launched`. Damit kann man zum Beispiel Umsetzten, dass direkt am Anfang eine Szene gestartet wird. Der entsprechende Issue ist #27.