### PR TITLE
Implementieren der Artikel-Kontrolle

### DIFF
--- a/Resources/world.xml
+++ b/Resources/world.xml
@@ -20,7 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <safe>
     <Place name="${game.places.alcove.name}" description="${game.places.alcove.description}" gender="m">
         <children>
-            <Player gender="f"/>
+            <Player/>
             <StaticEntity name="${game.places.alcove.hammock.name}" description="${game.places.alcove.hammock.description}" gender="f"/>
             <StaticEntity name="${game.places.alcove.window.name}" description="${game.places.alcove.window.description}" gender="n"/>
             <StaticEntity name="${game.places.alcove.mirror.name}" description="${game.places.alcove.mirror.description}" gender="m"/>
@@ -76,7 +76,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <StaticEntity name="${game.places.habour.container.name}" description="${game.places.habour.container.description}" gender="m" />
             <StaticEntity name="${game.places.habour.junkpile.name}" description="${game.places.habour.junkpile.description}" gender="m" />
             <StaticEntity name="${game.places.habour.oldBoat.name}" description="${game.places.habour.oldBoat.description}" gender="n" />
-            <StaticEntity name="${game.places.habour.ocean.name}" description="${game.places.habour.ocean.description}" gender="n" />
+            <StaticEntity name="${game.places.habour.ocean.name}" description="${game.places.habour.ocean.description}" gender="n">
+                <article definite="True"/>
+            </StaticEntity>
         </children>
         <connection name="${game.places.roadToHabour.name}"/>
     </Place>

--- a/Source/EngineL/Gameplay.py
+++ b/Source/EngineL/Gameplay.py
@@ -413,6 +413,8 @@ class Player(Core.Entity):
         Core.Entity.__init__(self, parent)
         self.setObjectName(Core.get_res_man().get_string("core.player.name"))
         self.description = "${core.player.description}"
+        self.gender = "f"
+        self.show_article = False
 
         self.window = ClientWindow()
         self.window.show()
@@ -468,19 +470,19 @@ class Player(Core.Entity):
                     return str()
 
             inventory_list = "${core.player.beginning} "
-            inventory_list += children[0].get_indefinite_article()
-            inventory_list += " <b>" + children[0].objectName() + "</b>"
+            inventory_list += children[0].get_effective_article() + " "
+            inventory_list += "<b>" + children[0].objectName() + "</b>"
 
             if len(children) > 2:
-                separator = string_key_root + "normalSeparator}"
                 for child in children[1:len(children)-1]:
-                    inventory_list += separator + " " + child.get_indefinite_article()
-                    inventory_list += " <b>" + child.objectName() + "</b>"
+                    inventory_list += string_key_root + "normalSeparator} "
+                    inventory_list += child.get_effective_article() + " "
+                    inventory_list += "<b>" + child.objectName() + "</b>"
 
             if len(children) >= 2:
                 inventory_list += " " + string_key_root + "lastSeparator} "
-                inventory_list += children[len(children)-1].get_indefinite_article()
-                inventory_list += " <b>" + children[len(children)-1].objectName() + "</b>"
+                inventory_list += children[len(children)-1].get_effective_article() + " "
+                inventory_list += "<b>" + children[len(children)-1].objectName() + "</b>"
 
             return inventory_list
         except LookupError as err:


### PR DESCRIPTION
Man kann jetzt sowohl im Quellcode als auch über die world.xml festlegen, welcher Artikel zu einem Gegenstand angegeben wird. Man kann einerseits zwischen dem definierten und dem undefiniertem Artikel wechseln ("das Meer" statt "ein Meer") und Artikel sogar komplett abschalten ("Ivy" statt "eine Ivy").

Im Quellcode selbst ist das über die boolschen Eigenschaften `show_article` und `use_definite_article` eines Gegenstands geregelt. Die `world.xml` hat dafür einen eigenen Unterpunkt bekommen, der die Eigenschaften `definite` und `shown` hat. Zum Beispiel könnten die Zeile 34 auch Lauten:

    <Oven name="${game.places.hut.oven.name}" description="${game.places.hut.oven.description}" gender="m">
        <article shown="True" definite="True"/>
    </Oven>

Das würde die Ausgabe "der Ofen" erzeugen. Dieser Unterpunkt ist allerdings nicht verpflichtend, kann also auch getrost weggelassen werden. Der entsprechende Issue dazu ist #26.