### PR TITLE
Erweitern der automatischen Beschreibungswiedergabe

### DIFF
--- a/Source/EngineL/Gameplay.py
+++ b/Source/EngineL/Gameplay.py
@@ -435,6 +435,13 @@ class Player(Core.Entity):
         """
         return self.gameplay_parser
 
+    def on_game_launched(self):
+        """
+        This constant, overriden method gets called when the game has just started and shows the
+        description of our current place.
+        """
+        self.get_window().show_text(self.parent().generate_description())
+
     def on_transfer(self, subject, parent, target):
         """
         This constant, overriden method does two things: First, if we are the the subject and we
@@ -445,13 +452,7 @@ class Player(Core.Entity):
         Core.Entity.on_transfer(self, subject, parent, target)
 
         if subject == self:
-            try:
-                visited = bool(target.get_state("visited"))
-            except KeyError:
-                visited = True
-            if not visited:
-                self.get_window().show_text(target.generate_description())
-                target.set_state("visited", 1)
+            self.get_window().show_text(target.generate_description())
 
         if target == self:
             message = "${core.player.beginning} " + subject.get_indefinite_article() + " "


### PR DESCRIPTION
Mir ist bei den letzten Test aufgefallen, dass die aktuelle automatische Wiedergabe noch nicht genug ist. Wenn ich zum Beispiel im Hafen bin und dann wieder zurück zum Dorf gehe, weiß ich natürlich nicht mehr, wie die ganzen Sachen dort heißen. Deswegen hab ich die automatische Wiedergabe so umgestellt, dass immer, wenn man einen Ort betritt, dessen Beschreibung ausgegeben wird. Auch wenn das Spiel startet, wird die Beschreibung des aktuellen Ortes ausgegeben, damit man sowohl beim Anfang als auch nach einer Pause wieder weiß, wo man war.

Was haltet ihr davon? Wollt ihr das übernehmen?