### PR TITLE
Implementieren von Abschnitt 5 und 6

### DIFF
--- a/Resources/Scenes/Gerrit0.xml
+++ b/Resources/Scenes/Gerrit0.xml
@@ -27,5 +27,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <text>"Das ist ein altes Windrad! Damit kannst du Strom erzeugen!"</text>
     <delay time="3000" />
     <text>"..."</text>
-    <spawn class="WindTurbine" target="Ivy" />
+    <spawn class="BrokenWindTurbine" target="Ivy" />
 </scene>

--- a/Resources/world.xml
+++ b/Resources/world.xml
@@ -123,7 +123,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </Place>
     <Place name="${game.places.eastSlope.name}" description="${game.places.eastSlope.description}" gender="m">
         <children>
-            <StaticEntity name="${game.places.eastSlope.junkpile.name}" description="${game.places.eastSlope.junkpile.description}" gender="m" />
+            <CoveredFountain name="${game.places.eastSlope.junkpile.name}" description="${game.places.eastSlope.junkpile.description}" gender="m" >
+                <children>
+                    <LadderTool />
+                </children>
+            </CoveredFountain>
         </children>
         <connection name="${game.places.mountainTop.name}"/>
     </Place>

--- a/Resources/world.xml
+++ b/Resources/world.xml
@@ -23,6 +23,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <StaticEntity name="${game.places.alcove.hammock.name}" description="${game.places.alcove.hammock.description}" gender="f"/>
             <StaticEntity name="${game.places.alcove.window.name}" description="${game.places.alcove.window.description}" gender="n"/>
             <StaticEntity name="${game.places.alcove.mirror.name}" description="${game.places.alcove.mirror.description}" gender="m"/>
+            <Player>
+                <children>
+                    <Stopper name="${game.places.alcove.stopper.name}" description="${game.places.alcove.stopper.description}" gender="m"/>
+                </children>
+            </Player>
         </children>
         <state key="visited" value="1"/>
         <connection name="${game.places.hut.name}"/>
@@ -60,12 +65,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <StaticEntity name="${game.places.village.house1.name}" description="${game.places.village.house1.description}" />
             <StaticEntity name="${game.places.village.house2.name}" description="${game.places.village.house2.description}" />
             <StaticEntity name="${game.places.village.house3.name}" description="${game.places.village.house3.description}" />
-
-            <Player>
-                <children>
-                    <Stopper name="${game.places.alcove.stopper.name}" description="${game.places.alcove.stopper.description}" gender="m"/>
-                </children>
-            </Player>
         </children>
         <connection name="${game.places.roadToIvy.name}"/>
         <connection name="${game.places.roadToHabour.name}"/>
@@ -93,9 +92,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <Place name="${game.places.field.name}" description="${game.places.field.description}" gender="n">
         <children>
             <StaticEntity name="${game.places.field.bed1.name}" description="${game.places.field.bed1.description}" gender="n" />
-            <StaticEntity name="${game.places.field.bed2.name}" description="${game.places.field.bed2.description}" gender="n" />
+            <StaticEntity name="${game.places.field.bed2.name}" description="${game.places.field.bed2.description}" gender="n">
+                <children>
+                    <Rungs />
+                </children>
+            </StaticEntity>
             <StaticEntity name="${game.places.field.bed3.name}" description="${game.places.field.bed3.description}" gender="n" />
-            <StaticEntity name="${game.places.field.bed4.name}" description="${game.places.field.bed4.description}" gender="n" />
+            <StaticEntity name="${game.places.field.bed4.name}" description="${game.places.field.bed4.description}" gender="n">
+                <children>
+                    <Stringers />
+                </children>
+            </StaticEntity>
             <StaticEntity name="${game.places.field.compostBin.name}" description="${game.places.field.compostBin.description}" gender="n" />
         </children>
         <connection name="${game.places.village.name}"/>

--- a/Resources/world.xml
+++ b/Resources/world.xml
@@ -50,6 +50,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     <Entity name="${game.places.yard.mysteriousFind.name}" description="${game.places.yard.mysteriousFind.description}" gender="n"/>
                 </children>
             </StaticEntity>
+            <Signpost />
         </children>
         <connection name="${game.places.hut.name}"/>
         <connection name="${game.places.roadToIvy.name}"/>
@@ -78,7 +79,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <Place name="${game.places.habour.name}" description="${game.places.habour.description}" gender="m">
         <children>
             <StaticEntity name="${game.places.habour.crane.name}" description="${game.places.habour.crane.description}" gender="m" />
-            <StaticEntity name="${game.places.habour.wall.name}" description="${game.places.habour.wall.description}" gender="f" />
+            <HabourWall name="${game.places.habour.wall.name}" description="${game.places.habour.wall.description}" gender="f" />
             <StaticEntity name="${game.places.habour.landingStage.name}" description="${game.places.habour.landingStage.description}" gender="m" />
             <StaticEntity name="${game.places.habour.container.name}" description="${game.places.habour.container.description}" gender="m" />
             <StaticEntity name="${game.places.habour.junkpile.name}" description="${game.places.habour.junkpile.description}" gender="m" />

--- a/Source/EngineL/Gameplay.py
+++ b/Source/EngineL/Gameplay.py
@@ -300,9 +300,12 @@ class GameplayParser(QObject):
         and transfering our parent, the player, to it. If it fails, it will post a message to the
         player that tells him so and nothing will be changed.
         """
-        target_name = self.get_argument_as_string()
-        app = QCoreApplication.instance()
-        target = app.findChild(Core.Entity, target_name, Qt.FindDirectChildrenOnly)
+        try:
+            target = self.parent().parent().get_connected_place(self.get_argument_as_string())
+        except LookupError:
+            self.window.show_text("${core.gameplayParser.invalidTargetMessage}")
+            return
+
         if target is None:
             self.window.show_text("${core.gameplayParser.invalidTargetMessage}")
         elif not self.parent().transfer(target):

--- a/Source/Habour.py
+++ b/Source/Habour.py
@@ -1,8 +1,7 @@
 """
-All classes required by the tutorial part of ProjectL
+This module contains the entities of the habour.
 
 Copyright (C) 2017 Jan-Oliver "Janonard" Opdenhövel
-Copyright (C) 2017 Jason "J2a0s0o0n" Becker
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -18,20 +17,26 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import Source.EngineL.Core as Core
-import Source.EngineL.Scene as Scene
+from Source.Ladder import FixedLadder
+from Source.WindTurbine import CopperCoil
 
-class GerritsHouse(Core.StaticEntity):
+class HabourWall(Core.Entity):
     """
-    This is the house of Gerrit Alt, Ivy's mentor.
+    The wall that holds the copper coil.
     """
     def __init__(self, parent=None):
-        Core.StaticEntity.__init__(self, parent)
+        Core.Entity.__init__(self, parent)
 
-    def on_talk_to(self, other_entity):
-        Scene.XMLScene("Gerrit0", other_entity).play()
+    def on_used(self, user, other_entity=None):
+        if isinstance(other_entity, FixedLadder):
+            coil = CopperCoil()
+            coil.transfer(user)
+            return True
+        else:
+            return False
 
 def register_entity_classes(app):
     """
     This function registers all of our new Entity classes to the given application instance.
     """
-    app.register_entity_classes([GerritsHouse])
+    app.register_entity_classes([HabourWall])

--- a/Source/Ladder.py
+++ b/Source/Ladder.py
@@ -1,5 +1,5 @@
 """
-This module contains all roads in the game since they belong to any other module.
+This module contains everything required to craft the ladder (and the ladder itself, of course).
 
 Copyright (C) 2017 Jan-Oliver "Janonard" Opdenhövel
 
@@ -87,7 +87,7 @@ class LadderTool(Core.Entity):
         self.setObjectName("WERKZEUG")
         self.description = "MIT DIESEM WERKZEUG KANN MAN DIE LEITER REPARIEREN"
         self.gender = "n"
-    
+
     def on_used(self, user, other_entity=None):
         if isinstance(other_entity, LooseLadder):
             return other_entity.on_used(user, self)

--- a/Source/Ladder.py
+++ b/Source/Ladder.py
@@ -1,0 +1,111 @@
+"""
+This module contains all roads in the game since they belong to any other module.
+
+Copyright (C) 2017 Jan-Oliver "Janonard" Opdenhövel
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+import Source.EngineL.Core as Core
+
+class Rungs(Core.Entity):
+    """
+    The rungs of a ladder.
+    """
+    def __init__(self, parent=None):
+        Core.Entity.__init__(self, parent)
+        self.setObjectName("SPROSSEN")
+        self.description = "DAS SIND MEHRERE SPROSSEN"
+        self.gender = "f"
+        self.show_article = False
+
+    def on_used(self, user, other_entity=None):
+        if isinstance(other_entity, Stringers):
+            self.transfer(None)
+            other_entity.transfer(None)
+            ladder = LooseLadder()
+            ladder.transfer(user)
+            user.get_window().show_text(ladder.generate_description())
+            return True
+        else:
+            return False
+
+class Stringers(Core.Entity):
+    """
+    The stringers of the ladder
+    """
+    def __init__(self, parent=None):
+        Core.Entity.__init__(self, parent)
+        self.setObjectName("HOLME")
+        self.description = "DAS SIND ZWEI HOLME"
+        self.gender = "m"
+        self.show_article = False
+
+    def on_used(self, user, other_entity=None):
+        if isinstance(other_entity, Rungs):
+            return other_entity.on_used(user, self)
+        else:
+            return False
+
+class LooseLadder(Core.Entity):
+    """
+    The loose, unfixed ladder.
+    """
+    def __init__(self, parent=None):
+        Core.Entity.__init__(self, parent)
+        self.setObjectName("WACKELIGE LEITER")
+        self.description = "DIESE LEITER IST WACKLIG UND MUSS REPARIERT WERDEN"
+        self.gender = "f"
+
+    def on_used(self, user, other_entity=None):
+        if isinstance(other_entity, LadderTool):
+            self.transfer(None)
+            other_entity.transfer(None)
+            ladder = FixedLadder()
+            ladder.transfer(user)
+            user.get_window().show_text(ladder.generate_description())
+            return True
+        else:
+            return False
+
+class LadderTool(Core.Entity):
+    """
+    The tool needed to fix the ladder
+    """
+    def __init__(self, parent=None):
+        Core.Entity.__init__(self, parent)
+        self.setObjectName("WERKZEUG")
+        self.description = "MIT DIESEM WERKZEUG KANN MAN DIE LEITER REPARIEREN"
+        self.gender = "n"
+    
+    def on_used(self, user, other_entity=None):
+        if isinstance(other_entity, LooseLadder):
+            return other_entity.on_used(user, self)
+        else:
+            return False
+
+class FixedLadder(Core.Entity):
+    """
+    The fixed ladder.
+    """
+    def __init__(self, parent=None):
+        Core.Entity.__init__(self, parent)
+        self.setObjectName("LEITER")
+        self.description = "MIT DIESER LEITER KOMMT MAN FAST ÜBERALL HIN"
+        self.gender = "f"
+
+def register_entity_classes(app):
+    """
+    This function registers all of our new Entity classes to the given application instance.
+    """
+    app.register_entity_classes([Rungs, Stringers, LooseLadder, LadderTool, FixedLadder])

--- a/Source/Ladder.py
+++ b/Source/Ladder.py
@@ -104,6 +104,12 @@ class FixedLadder(Core.Entity):
         self.description = "MIT DIESER LEITER KOMMT MAN FAST ÜBERALL HIN"
         self.gender = "f"
 
+    def on_used(self, user, other_entity=None):
+        if other_entity is not None:
+            return other_entity.on_used(user, self)
+        else:
+            return False
+
 def register_entity_classes(app):
     """
     This function registers all of our new Entity classes to the given application instance.

--- a/Source/Mountain.py
+++ b/Source/Mountain.py
@@ -34,11 +34,15 @@ class CoveredFountain(Core.Entity):
         ladder tool and the target is the player (which means that the player took the tools).
         """
         Core.Entity.on_transfer(self, subject, parent, target)
-        if isinstance(subject, LadderTool) and isinstance(target, Player):
+        if isinstance(subject, LadderTool):
             rth_name = Core.get_res_man().get_string("game.places.roadToHabour.name")
             road_to_habour = Core.SinglePlayerApp.instance().findChild(Core.Place, rth_name)
             road_to_habour.set_state("flooded", 1)
-            target.get_window().show_text("EINE QUELLE HAT SICH GEÖFFNET UND EIN FLUSS FLIEßT")
+
+            player_name = Core.get_res_man().get_string("core.player.name")
+            player = Core.SinglePlayerApp.instance().findChild(Player, player_name)
+            if player is not None:
+                player.get_window().show_text("EINE QUELLE HAT SICH GEÖFFNET UND EIN FLUSS FLIEßT")
 
 def register_entity_classes(app):
     """

--- a/Source/Mountain.py
+++ b/Source/Mountain.py
@@ -1,0 +1,47 @@
+"""
+This module contains the scrap heap on the mountain, which also happens to be a fountain.
+
+Copyright (C) 2017 Jan-Oliver "Janonard" Opdenhövel
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+import Source.EngineL.Core as Core
+from Source.EngineL.Gameplay import Player
+from  Source.Ladder import LadderTool
+
+class CoveredFountain(Core.Entity):
+    """
+    This is a scrap heap which also holds the tools to fix up the ladder. When the player uses it,
+    it also floods the road to the habour.
+    """
+    def __init__(self, parent=None):
+        Core.Entity.__init__(self, parent)
+
+    def on_transfer(self, subject, parent, target):
+        """
+        This non-constant, overriden method floods the habour road if the given subject is the
+        ladder tool and the target is the player (which means that the player took the tools).
+        """
+        Core.Entity.on_transfer(self, subject, parent, target)
+        if isinstance(subject, LadderTool) and isinstance(target, Player):
+            rth_name = Core.get_res_man().get_string("game.places.roadToHabour.name")
+            road_to_habour = Core.SinglePlayerApp.instance().findChild(Core.Place, rth_name)
+            road_to_habour.set_state("flooded", 1)
+            target.get_window().show_text("EINE QUELLE HAT SICH GEÖFFNET UND EIN FLUSS FLIEßT")
+
+def register_entity_classes(app):
+    """
+    This function registers all of our new Entity classes to the given application instance.
+    """
+    app.register_entity_classes([CoveredFountain])

--- a/Source/WindTurbine.py
+++ b/Source/WindTurbine.py
@@ -1,0 +1,104 @@
+"""
+This module contains everything required to craft the wind turbine.
+
+Copyright (C) 2017 Jan-Oliver "Janonard" Opdenhövel
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+import Source.EngineL.Core as Core
+
+class BrokenWindTurbine(Core.Entity):
+    """
+    A wind turbine, formerly the mysterious find.
+    """
+    def __init__(self, parent=None):
+        Core.Entity.__init__(self, parent)
+        self.setObjectName("KAPUTTES WINDRAD")
+        self.description = "EIN KAPUTTES WINDRAD"
+
+    def on_used(self, user, other_entity=None):
+        if isinstance(other_entity, CopperCoil):
+            self.transfer(None)
+            other_entity.transfer(None)
+            turbine = WindTurbine()
+            turbine.transfer(user)
+            user.get_window().show_text(turbine.generate_description())
+            return True
+        else:
+            return False
+
+class CopperCoil(Core.Entity):
+    """
+    The copper coil which is needed to build the wind turbine.
+    """
+    def __init__(self, parent=None):
+        Core.Entity.__init__(self, parent)
+        self.setObjectName("KUPFERSPULE")
+        self.description = "EINE KUPFERSPULE"
+
+    def on_used(self, user, other_entity=None):
+        if other_entity is not None:
+            return other_entity.on_used(user, self)
+        else:
+            return False
+
+class WindTurbine(Core.Entity):
+    """
+    The fixed wind turbine.
+    """
+    def __init__(self, parent=None):
+        Core.Entity.__init__(self, parent)
+        self.setObjectName("WINDRAD")
+        self.description = "EIN WINDRAD"
+
+    def on_used(self, user, other_entity=None):
+        if other_entity is not None:
+            return other_entity.on_used(user, self)
+        else:
+            return False
+
+class Signpost(Core.StaticEntity):
+    """
+    An unused signpost in Ivy's yard, which will be reused as the pole of her wind turbine.
+    """
+    def __init__(self, parent=None):
+        Core.StaticEntity.__init__(self, parent)
+        self.setObjectName("WEGWEISER")
+
+    def on_used(self, user, other_entity=None):
+        if isinstance(other_entity, WindTurbine):
+            other_entity.transfer(None)
+            self.set_state("turbine mounted", 1)
+            self.setObjectName("AUFGESTELLTES WINDRAD")
+            user.get_window().show_text(self.generate_description())
+            return True
+        else:
+            return False
+
+    def get_raw_description(self):
+        try:
+            turbine_mounted = bool(self.get_state("turbine mounted"))
+        except KeyError:
+            turbine_mounted = False
+
+        if turbine_mounted:
+            return "DAS WINDRAD PRODUZIERT STROM."
+        else:
+            return "DAS IST EIN WEGWEISER"
+
+def register_entity_classes(app):
+    """
+    This function registers all of our new Entity classes to the given application instance.
+    """
+    app.register_entity_classes([BrokenWindTurbine, CopperCoil, WindTurbine, Signpost])

--- a/Source/__init__.py
+++ b/Source/__init__.py
@@ -21,6 +21,7 @@ import Source.EngineL
 import Source.Hut
 import Source.Roads
 import Source.Village
+import Source.Ladder
 
 class Game(Source.EngineL.Core.SinglePlayerApp):
     """
@@ -34,6 +35,7 @@ class Game(Source.EngineL.Core.SinglePlayerApp):
             Source.Hut.register_entity_classes(self)
             Source.Roads.register_entity_classes(self)
             Source.Village.register_entity_classes(self)
+            Source.Ladder.register_entity_classes(self)
 
             self.restore_world()
 

--- a/Source/__init__.py
+++ b/Source/__init__.py
@@ -22,6 +22,7 @@ import Source.Hut
 import Source.Roads
 import Source.Village
 import Source.Ladder
+import Source.Mountain
 
 class Game(Source.EngineL.Core.SinglePlayerApp):
     """
@@ -36,6 +37,7 @@ class Game(Source.EngineL.Core.SinglePlayerApp):
             Source.Roads.register_entity_classes(self)
             Source.Village.register_entity_classes(self)
             Source.Ladder.register_entity_classes(self)
+            Source.Mountain.register_entity_classes(self)
 
             self.restore_world()
 

--- a/Source/__init__.py
+++ b/Source/__init__.py
@@ -18,11 +18,13 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import Source.EngineL
+import Source.Habour
 import Source.Hut
-import Source.Roads
-import Source.Village
 import Source.Ladder
 import Source.Mountain
+import Source.Roads
+import Source.Village
+import Source.WindTurbine
 
 class Game(Source.EngineL.Core.SinglePlayerApp):
     """
@@ -33,11 +35,14 @@ class Game(Source.EngineL.Core.SinglePlayerApp):
 
         try:
             Source.EngineL.Gameplay.register_entity_classes(self)
+
+            Source.Habour.register_entity_classes(self)
             Source.Hut.register_entity_classes(self)
-            Source.Roads.register_entity_classes(self)
-            Source.Village.register_entity_classes(self)
             Source.Ladder.register_entity_classes(self)
             Source.Mountain.register_entity_classes(self)
+            Source.Roads.register_entity_classes(self)
+            Source.Village.register_entity_classes(self)
+            Source.WindTurbine.register_entity_classes(self)
 
             self.restore_world()
 


### PR DESCRIPTION
Ich hab jetzt Abschnitt 5 und 6 umgesetzt, allerdings musste ich das Minispiel mit dem Zusammenbauen der Leiter ändern, da "Leiterteil" und "Leiterteil" nicht besonders bildhaft ist.

Ich habe jetzt zwei Leiterteile eingefügt: "SPROSSEN" und "HOLME", also jeweils eine Sammlung von Teilen, die durch einen Gegenstand dargestellt werden. Diese werden zu einer "WACKELIGE LEITER" zusammengefügt und mit dem "WERKZEUG" zu einer "LEITER" vervollständigt.

Das Werkzeug liegt, wie abgesprochen, auf dem Schrotthaufen in den Bergen und wenn man das Werkzeug aufhebt, wird eine kurze Meldung ausgegeben, dass sich ein Fluss gebildet hat und der Status "flooded" des Hafenweges wird auf 1 gesetzt. Ansonsten merkt man natürlich noch nichts davon, das ist aber auch ein anderer Abschnitt.

Ich habe mich auch komplett von der `strings.xml` fern gehalten, @Flummi3 muss also noch meine gehardcodeten Texte ersetzten. Ich hoffe, das Ganze gefällt euch so.