### PR TITLE
Zwei Bugfixes

### DIFF
--- a/Source/EngineL/Core.py
+++ b/Source/EngineL/Core.py
@@ -130,6 +130,7 @@ class Entity(QObject):
         self.gender = "n"
         self.show_article = True
         self.use_definite_article = False
+        self.activly_usable = False
 
     def transfer(self, targeted_parent):
         """
@@ -237,14 +238,18 @@ class Entity(QObject):
         This non-constant, abstract method executes the tasks that the user abstractly does with
         ourselves and an optional other entity and returns whether this was successfull or not.
 
-        At default, it returns False since you can not do anything with ourselves if this method
-        is not overridden.
+        At default, it has two modes: If self.activly_usable is True, it will try to pass the
+        on_used to the other_entity and will return it's return value. If this did not work or
+        self.activly_usable is False, it will return False.
 
         One example on how this may be overriden in a usefull way: The user wants to combine
         ourselves with another entity to create a new one. This method would check whether the other
         entity has the required type, would add the new one and disconnect us and the other entity
         from the world tree.
         """
+        if other_entity is not None:
+            if (not self.activly_usable) and other_entity.activly_usable:
+                return other_entity.on_used(user, self)
         return False
 
     def get_raw_description(self):
@@ -527,6 +532,12 @@ class Entity(QObject):
         we want the indefinite one.
         """
         return self.use_definite_article
+    
+    def get_activly_usable(self):
+        """
+        This constant method returns True if we are activly usable and False if not.
+        """
+        return self.activly_usable
 
 class StaticEntity(Entity):
     """

--- a/Source/EngineL/Core.py
+++ b/Source/EngineL/Core.py
@@ -139,11 +139,16 @@ class Entity(QObject):
         afterwards.
         """
         transfer_okay = True
+        if self.parent() == targeted_parent:
+            transfer_okay = False
+
         if not self.check_transfer_as_subject(targeted_parent):
             transfer_okay = False
+
         if self.parent() is not None:
             if not self.parent().check_transfer_as_parent(self, targeted_parent):
                 transfer_okay = False
+
         if targeted_parent is not None:
             if not targeted_parent.check_transfer_as_target(self):
                 transfer_okay = False

--- a/Source/Habour.py
+++ b/Source/Habour.py
@@ -26,6 +26,7 @@ class HabourWall(Core.Entity):
     """
     def __init__(self, parent=None):
         Core.Entity.__init__(self, parent)
+        self.activly_usable = True
 
     def on_used(self, user, other_entity=None):
         if isinstance(other_entity, FixedLadder):

--- a/Source/Hut.py
+++ b/Source/Hut.py
@@ -27,6 +27,7 @@ class Sofa(Core.StaticEntity):
     def __init__(self, parent=None):
         Core.StaticEntity.__init__(self, parent)
         self.set_state("timesScanned", 0)
+        self.activly_usable = True
 
     def on_used(self, user, other_entity=None):
         """
@@ -53,6 +54,7 @@ class Jam(Core.Entity):
         Core.Entity.__init__(self, parent)
         self.setObjectName(Core.get_res_man().get_string("game.places.hut.jam.name"))
         self.set_gender("f")
+        self.activly_usable = True
 
     def on_used(self, user, other_entity=None):
         """
@@ -77,6 +79,7 @@ class Oven(Core.StaticEntity):
     def __init__(self, parent=None):
         Core.StaticEntity.__init__(self, parent)
         self.set_state("on", 0)
+        self.activly_usable = True
 
     def on_used(self, user, other_entity=None):
         """
@@ -120,15 +123,6 @@ class Wood(Core.Entity):
         Core.Entity.__init__(self, parent)
         self.setObjectName(Core.get_res_man().get_string("game.places.yard.wood.name"))
 
-    def on_used(self, user, other_entity=None):
-        """
-        This non-constant, overriden method does something.
-        """
-        if isinstance(other_entity, Oven):
-            return other_entity.on_used(user, self)
-        else:
-            return False
-
 class Toast(Core.Entity):
     """
     the Toast
@@ -139,6 +133,7 @@ class Toast(Core.Entity):
         self.set_state("toasted", 0)
         self.set_state("coated", 0)
         self.setObjectName(Core.get_res_man().get_string("game.places.hut.toast.name"))
+        self.activly_usable = True
 
     def on_used(self, user, other_entity=None):
         """
@@ -176,6 +171,7 @@ class HoleInRoof(Core.StaticEntity):
     """
     def __init__(self, parent=None):
         Core.StaticEntity.__init__(self, parent)
+        self.activly_usable = True
 
     def on_used(self, user, other_entity=None):
         """
@@ -196,16 +192,6 @@ class Stopper(Core.Entity):
     """
     def __init__(self, parent=None):
         Core.Entity.__init__(self, parent)
-
-    def on_used(self, user, other_entity=None):
-        """
-        This non-constant method passes the on_used-event to the other_entity and returns it's
-        return value. If no other_entity were given, it will return False.
-        """
-        if other_entity is not None:
-            return other_entity.on_used(user, self)
-        else:
-            return False
 
 def register_entity_classes(app):
     """

--- a/Source/Ladder.py
+++ b/Source/Ladder.py
@@ -28,6 +28,7 @@ class Rungs(Core.Entity):
         self.description = "DAS SIND MEHRERE SPROSSEN"
         self.gender = "f"
         self.show_article = False
+        self.activly_usable = True
 
     def on_used(self, user, other_entity=None):
         if isinstance(other_entity, Stringers):
@@ -51,12 +52,6 @@ class Stringers(Core.Entity):
         self.gender = "m"
         self.show_article = False
 
-    def on_used(self, user, other_entity=None):
-        if isinstance(other_entity, Rungs):
-            return other_entity.on_used(user, self)
-        else:
-            return False
-
 class LooseLadder(Core.Entity):
     """
     The loose, unfixed ladder.
@@ -66,6 +61,7 @@ class LooseLadder(Core.Entity):
         self.setObjectName("WACKELIGE LEITER")
         self.description = "DIESE LEITER IST WACKLIG UND MUSS REPARIERT WERDEN"
         self.gender = "f"
+        self.activly_usable = True
 
     def on_used(self, user, other_entity=None):
         if isinstance(other_entity, LadderTool):
@@ -88,12 +84,6 @@ class LadderTool(Core.Entity):
         self.description = "MIT DIESEM WERKZEUG KANN MAN DIE LEITER REPARIEREN"
         self.gender = "n"
 
-    def on_used(self, user, other_entity=None):
-        if isinstance(other_entity, LooseLadder):
-            return other_entity.on_used(user, self)
-        else:
-            return False
-
 class FixedLadder(Core.Entity):
     """
     The fixed ladder.
@@ -103,12 +93,6 @@ class FixedLadder(Core.Entity):
         self.setObjectName("LEITER")
         self.description = "MIT DIESER LEITER KOMMT MAN FAST ÜBERALL HIN"
         self.gender = "f"
-
-    def on_used(self, user, other_entity=None):
-        if other_entity is not None:
-            return other_entity.on_used(user, self)
-        else:
-            return False
 
 def register_entity_classes(app):
     """

--- a/Source/Mountain.py
+++ b/Source/Mountain.py
@@ -27,6 +27,7 @@ class CoveredFountain(Core.Entity):
     """
     def __init__(self, parent=None):
         Core.Entity.__init__(self, parent)
+        self.activly_usable = True
 
     def on_transfer(self, subject, parent, target):
         """

--- a/Source/WindTurbine.py
+++ b/Source/WindTurbine.py
@@ -26,6 +26,7 @@ class BrokenWindTurbine(Core.Entity):
         Core.Entity.__init__(self, parent)
         self.setObjectName("KAPUTTES WINDRAD")
         self.description = "EIN KAPUTTES WINDRAD"
+        self.activly_usable = True
 
     def on_used(self, user, other_entity=None):
         if isinstance(other_entity, CopperCoil):
@@ -47,12 +48,6 @@ class CopperCoil(Core.Entity):
         self.setObjectName("KUPFERSPULE")
         self.description = "EINE KUPFERSPULE"
 
-    def on_used(self, user, other_entity=None):
-        if other_entity is not None:
-            return other_entity.on_used(user, self)
-        else:
-            return False
-
 class WindTurbine(Core.Entity):
     """
     The fixed wind turbine.
@@ -62,12 +57,6 @@ class WindTurbine(Core.Entity):
         self.setObjectName("WINDRAD")
         self.description = "EIN WINDRAD"
 
-    def on_used(self, user, other_entity=None):
-        if other_entity is not None:
-            return other_entity.on_used(user, self)
-        else:
-            return False
-
 class Signpost(Core.StaticEntity):
     """
     An unused signpost in Ivy's yard, which will be reused as the pole of her wind turbine.
@@ -75,6 +64,7 @@ class Signpost(Core.StaticEntity):
     def __init__(self, parent=None):
         Core.StaticEntity.__init__(self, parent)
         self.setObjectName("WEGWEISER")
+        self.activly_usable = True
 
     def on_used(self, user, other_entity=None):
         if isinstance(other_entity, WindTurbine):


### PR DESCRIPTION
Der erste betrifft einen theoretischen Bug: Wenn man eine Kombination hat, ist es meistens unwichtig, in welcher Reihenfolge die einzelnen Elemente aufgeführt werden: "kombiniere foo mit bar" hat den gleichen Effekt wie "kombiniere bar mit foo". Das liegt daran, dass einer der beiden Gegenstände die Kombination ausführt und der andere die Anfrage nur weiterleitet. Kombiniert man aber zwei Gegenstände miteinander, die beide die Anfrage weiterleiten wollen, hat man eine unendliche Schleife.

Das Problem ist dadurch gelöst, dass es jetzt die Eigenschaft (kein Status) `activly_usable` gibt. Die Standart-Implementierung von `on_used` prüft jetzt nach, ob der Gegenüber `activly_usable` ist und man selbst es nicht ist. Dann, und nur dann wird die Anfrage weitergeleitet. Durch diese Änderung muss aber im Konstruktor einer Klasse mit überschriebener `on_used`-Methode `activly_usable` auf `True` gesetzt werden.

Der zweite Fix betrifft Bug #48 und verbietet einfach Transfers, bei dem der derzeitige Vater auch der Zukünftige ist.