### PR TITLE
Fixen des Bugs mit der doppelten Überflutung

### DIFF
--- a/Source/Minigame.py
+++ b/Source/Minigame.py
@@ -164,7 +164,7 @@ class Dam(Core.StaticEntity):
             other_entity.transfer(None)
             rth_name = Core.get_res_man().get_string("game.places.roadToHabour.name")
             road_to_habour = Core.SinglePlayerApp.instance().findChild(Core.Place, rth_name)
-            road_to_habour.set_state("flooded", 0)
+            road_to_habour.set_state("cleared", 1)
             return True
         return False
 

--- a/Source/Roads.py
+++ b/Source/Roads.py
@@ -61,6 +61,7 @@ class RoadToHabour(Core.Place):
     def __init__(self, parent=None):
         Core.Place.__init__(self, parent)
         self.set_state("flooded", 0)
+        self.set_state("cleared", 0)
     def on_transfer(self, subject, parent, target):
         """
         This non-constant, overriden method starts the scene 'Hex0' if Ivy hadn't met her before.
@@ -92,7 +93,7 @@ class RoadToHabour(Core.Place):
         """
         if Core.Place.check_transfer_as_parent(self, subject, target):
             if isinstance(target, Habour):
-                if self.get_state("flooded") == 0:
+                if self.get_state("flooded") == 0 or self.get_state("cleared") == 1:
                     return True
                 else:
                     subject.get_window().show_text("Ich komme nicht an dem Fluss vorbei!")


### PR DESCRIPTION
Ich habe den Bug gefixt, durch den der Hafenweg mehrfach überflutet werden konnte: Jetzt bleibt der Hafen überflutet wenn er es einmal ist, aber dafür wird er gesäubert. Man kann daher zum Hafen gehen, wenn der Weg entweder nicht überflutet oder gesäubert ist.